### PR TITLE
contestant/kali: Add ip and ping to container

### DIFF
--- a/contestant_containers/Dockerfile.kali
+++ b/contestant_containers/Dockerfile.kali
@@ -1,7 +1,7 @@
 FROM docker.io/kalilinux/kali-rolling
 RUN DEBIAN_FRONTEND=noninteractive DEBCONF_NONINTERACTIVE_SEEN=true apt-get update && \
   DEBIAN_FRONTEND=noninteractive DEBCONF_NONINTERACTIVE_SEEN=true apt-get dist-upgrade -y && \
-  DEBIAN_FRONTEND=noninteractive DEBCONF_NONINTERACTIVE_SEEN=true apt-get install --no-install-recommends -y aircrack-ng asleap freeradius-wpe hostapd-wpe iw kismet mdk3 mdk4 pixiewps reaver wifi-honey wifite tshark wireshark termshark vim mlocate man pciutils hashcat wpasupplicant less bash-completion ssh supervisor novnc xvfb x11vnc kali-desktop-xfce dbus-x11 dialog librsvg2-common tmux tcpdump nmap && \
+  DEBIAN_FRONTEND=noninteractive DEBCONF_NONINTERACTIVE_SEEN=true apt-get install --no-install-recommends -y aircrack-ng asleap freeradius-wpe hostapd-wpe iw kismet mdk3 mdk4 pixiewps reaver wifi-honey wifite tshark wireshark termshark vim mlocate man pciutils hashcat wpasupplicant less bash-completion ssh supervisor novnc xvfb x11vnc kali-desktop-xfce dbus-x11 dialog librsvg2-common tmux tcpdump nmap iproute2 iputils-ping && \
   #dpkg -P --force-depends xfce4-power-manager-plugins && \
   #rm -f /root/.config/xfce4/xfconf/xfce-perchannel-xml/xfce4-power-manager.xml && \
   #sed -i '/power-manager-plugin/d' /root/.config/xfce4/xfconf/xfce-perchannel-xml/xfce4-panel.xml && \


### PR DESCRIPTION
This commit adds `ip` and `ping` to the Kali container to bring some parity with the Pentoo container.